### PR TITLE
Restore admin import to Django Admin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ class TestModelAdmin(ModelAdmin):
 **to**
 
 ```python
+from django.contrib import admin
 from model_clone import CloneModelAdmin
 
 @admin.register(TestModel)


### PR DESCRIPTION
I believe this was an oversight. The `@admin.register()` decorator does not function without it and my app requires `TabularInline`. Your own [sample](https://raw.githubusercontent.com/tj-django/django-clone/main/sample/admin.py) requires it.